### PR TITLE
3.0alpha3

### DIFF
--- a/gqylpy_exception/__init__.py
+++ b/gqylpy_exception/__init__.py
@@ -5,7 +5,7 @@ need to define an exception class in advance, Convenient and Fast.
     >>> import gqylpy_exception as ge
     >>> raise ge.AnError(...)
 
-    @version: 3.0alpha2
+    @version: 3.0alpha3
     @author: 竹永康 <gqylpy@outlook.com>
     @source: https://github.com/gqylpy/gqylpy-exception
 


### PR DESCRIPTION
1.Optimize `MasqueradeClass` and fix one of the errors.
2.Improve the scheme for prohibit modify `__history__` dictionary in externaly.
3.Fix `SingletonMode` mode metaclass not hidden issue.

1.优化 `MasqueradeClass`，并修正其中的一处错误。
2.改进禁止外部修改 `__history__` 字典的方案。
3.修复 `SingletonMode` 模式下元类不被隐藏的问题。